### PR TITLE
Proper formatting for timestamps

### DIFF
--- a/timber-junit/src/main/java/net/lachlanmckee/timberjunit/TimberTestRule.java
+++ b/timber-junit/src/main/java/net/lachlanmckee/timberjunit/TimberTestRule.java
@@ -313,7 +313,7 @@ public class TimberTestRule implements TestRule {
             new ThreadLocal<DateFormat>() {
                 @Override
                 protected DateFormat initialValue() {
-                    return new SimpleDateFormat("HH:mm:ss:SSSSSSS", Locale.ENGLISH);
+                    return new SimpleDateFormat("HH:mm:ss.SSS", Locale.ENGLISH);
                 }
             };
 


### PR DESCRIPTION
The `SSS` indicates milliseconds, so there should be exactly 3 (not 7). Also, typically it is formatted with a decimal point after seconds, not a colon.